### PR TITLE
feat: template completions

### DIFF
--- a/snippets/tpl-tags-builtin.code-snippets
+++ b/snippets/tpl-tags-builtin.code-snippets
@@ -3,13 +3,13 @@
         "scope": "tpl",
         "description": "{% all catinclude %}",
         "prefix": "all catinclude",
-        "body": "{% all catinclude \"$0.tpl\" %}"
+        "body": "{% all catinclude \"$1\" %}"
     },
     "all include": {
         "scope": "tpl",
         "description": "{% all include %}",
         "prefix": "all include",
-        "body": "{% all include \"$0.tpl\" %}"
+        "body": "{% all include \"$1\" %}"
     },
     "autoescape": {
         "scope": "tpl",
@@ -57,7 +57,7 @@
         "scope": "tpl",
         "description": "{% catinclude %}",
         "prefix": "catinclude",
-        "body": "{% catinclude \"$0.tpl\" %}"
+        "body": "{% catinclude \"$1\" %}"
     },
     "comment": {
         "scope": "tpl",
@@ -97,7 +97,7 @@
         "scope": "tpl",
         "description": "{% extends %}",
         "prefix": "extends",
-        "body": "{% extends \"$0.tpl\" %}"
+        "body": "{% extends \"$1\" %}"
     },
     "filter": {
         "scope": "tpl",
@@ -223,7 +223,7 @@
         "scope": "tpl",
         "description": "{% include %}",
         "prefix": "include",
-        "body": "{% include \"$0.tpl\" %}"
+        "body": "{% include \"$1\" %}"
     },
     "inherit": {
         "scope": "tpl",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,7 +112,7 @@ export function activate(context: vscode.ExtensionContext) {
 			const tplRange = document.getWordRangeAtPosition(position, tplRe);
 			if (tplRange && !tplRange.isEmpty) {
 				// TODO: If is include, provide vars completion.
-				const templateRe = /(?<={%\s*(include|extends)\s*\").*?(?=")/;
+				const templateRe = /(?<={%\s*(extends|(all\s*)?((cat)?include))\s*\").*?(?=")/;
 				const templateRange = document.getWordRangeAtPosition(position, templateRe);
 				if (!!templateRange) {
 					const templatesPattern = "{apps,apps_user}/**/priv/templates/**/*.tpl";

--- a/src/test/test.tpl
+++ b/src/test/test.tpl
@@ -1,5 +1,8 @@
 {% extends "" %}
 {% include "" %}
+{% catinclude "" %}
+{% all include "" %}
+{% all catinclude "" %}
 
 <a href="{% url admin_edit_rsc id=42 foo="bar" absolute_url %}"></a>
 

--- a/src/test/test.tpl
+++ b/src/test/test.tpl
@@ -1,3 +1,6 @@
+{% extends "" %}
+{% include "" %}
+
 <a href="{% url admin_edit_rsc id=42 foo="bar" absolute_url %}"></a>
 
 <h1 class="title {% if m.req.csp_nonce as foo %}{{ foo }}{% else %}bar{% endif %}">My title</h1>


### PR DESCRIPTION
Provide completions for `extends`, `include`, `catinclude`, `all include` and `all catinclude` tags.
![include_extends_snippets](https://user-images.githubusercontent.com/35941533/174440140-9beb94a9-2e73-4700-9ffe-26d23ec988af.gif)

